### PR TITLE
Change require to import syntax

### DIFF
--- a/src/Core/Core.js
+++ b/src/Core/Core.js
@@ -3,7 +3,7 @@
  */
 
 import axios from 'axios';
-var _defaultsDeep = require('lodash').defaultsDeep;
+import { defaultsDeep } from 'lodash';
 
 import Defaults from './Defaults';
 import Debugger from './../Debug/Debugger';
@@ -13,7 +13,7 @@ class Core {
     constructor (config) {
         config = config || {};
 
-        config = _defaultsDeep(config, Defaults);
+        config = defaultsDeep(config, Defaults);
 
         this.initialize(config);
     }
@@ -77,7 +77,7 @@ class Core {
      * Initialize the API.
      */
     initializeAPI () {
-        this.api = axios.create(_defaultsDeep({ baseURL: this.config.baseURL.replace(/\/$/, '') }, this.config.apiConfig));
+        this.api = axios.create(defaultsDeep({ baseURL: this.config.baseURL.replace(/\/$/, '') }, this.config.apiConfig));
     }
 
     /**

--- a/src/Core/Request.js
+++ b/src/Core/Request.js
@@ -3,8 +3,7 @@
  */
 
 import Routes from './Routes';
-var _isArray = require('lodash').isArray;
-var _defaultsDeep = require('lodash').defaultsDeep;
+import { isArray, defaultsDeep } from 'lodash';
 
 class Request extends Routes {
     constructor (config) {
@@ -23,11 +22,11 @@ class Request extends Routes {
 
         // axios handles the options differently for the request type
         if(['put', 'post', 'patch'].includes(type)) {
-            params = _defaultsDeep(params, this.config.globalParameters);
+            params = defaultsDeep(params, this.config.globalParameters);
             requestData.push(params);
             requestData.push(options);
         } else {
-            options.params = _defaultsDeep(params, this.config.globalParameters);
+            options.params = defaultsDeep(params, this.config.globalParameters);
             requestData.push(options);
         }
 
@@ -95,7 +94,7 @@ class Request extends Routes {
             this.resetURLParams();
         }
 
-        let url = _isArray(urlParams) ? this.makeUrl(...urlParams) : this.makeUrl(urlParams);
+        let url = isArray(urlParams) ? this.makeUrl(...urlParams) : this.makeUrl(urlParams);
 
         return this.request(type, url);
     }
@@ -192,7 +191,7 @@ class Request extends Routes {
      * @param data An object of params: {}, options: {}
      */
     withData (data = {}) {
-        this.requestData = _defaultsDeep(data, this.requestData);
+        this.requestData = defaultsDeep(data, this.requestData);
 
         return this;
     }

--- a/src/Core/Routes.js
+++ b/src/Core/Routes.js
@@ -4,7 +4,7 @@
 
 import Url from './Url';
 import pluralize from 'pluralize';
-var _kebabCase = require('lodash').kebabCase;
+import { kebabCase } from 'lodash';
 
 class Routes extends Url {
 
@@ -39,7 +39,7 @@ class Routes extends Url {
         if(this.config.routes[route] != '') {
             newRoute = this.config.routes[route];
         } else {
-            newRoute = _kebabCase(formattedRoute[route]).replace(/-/g, this.config.routeDelimeter);
+            newRoute = kebabCase(formattedRoute[route]).replace(/-/g, this.config.routeDelimeter);
 
             if(this.config.caseSensitive) {
                 newRoute = formattedRoute[route];

--- a/src/Core/Url.js
+++ b/src/Core/Url.js
@@ -3,7 +3,7 @@
  */
 
 import Core from './Core';
-var _isArray = require('lodash').isArray;
+import { isArray } from 'lodash';
 
 class Url extends Core {
     constructor (config) {
@@ -60,7 +60,7 @@ class Url extends Core {
     setURLParams (urlParams = [], prepend = false, overwrite = false) {
         this.urlParams = this.urlParams || [];
 
-        if(!_isArray(urlParams)) {
+        if(!isArray(urlParams)) {
             urlParams = [urlParams];
         }
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,5 +1,5 @@
 import Rapid from './Core/Rapid';
-var _defaultsDeep = require('lodash').defaultsDeep;
+import { defaultsDeep } from 'lodash';
 
 var authConfig = {
     auth: {
@@ -22,7 +22,7 @@ var authConfig = {
 class Auth extends Rapid {
 
     constructor (config) {
-        config = _defaultsDeep(config, authConfig);
+        config = defaultsDeep(config, authConfig);
         config.modelName = config.modelName ? config.modelName : 'auth';
 
         super(config);

--- a/src/rapid.js
+++ b/src/rapid.js
@@ -1,3 +1,3 @@
-var Rapid = require('./Core/Rapid');
+import Rapid from './Core/Rapid';
 
 module.exports = Rapid;


### PR DESCRIPTION
In certain files a require statement is used to import methods from lodash; this is a bit inconsistent with the rest of the codebase since it uses import statements mostly. 

Changes this:
`var _defaultsDeep = require('lodash').defaultsDeep;`

To this:
`import { defaultsDeep } from 'lodash';`

Tests passed when ran.