### PR TITLE
Added installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@
 
 Read the official docs at [https://rapidjs.io](https://rapidjs.io).
 
+## Installation
+
+Pick your poison:
+
+```
+yarn add rapid.js
+npm i -S rapid.js
+npm install --save rapid.js
+```
+
 ## Overview
  - [Define Simple Models](#define-simple-models)
  - [Easily Customize Your API Requests](#easily-customize-your-api-requests)


### PR DESCRIPTION
I went to install the package and tried to install the following first:

```
yarn add rapidjs
yarn add rapid-js
```

It wasn't clear that the package was actually `rapid.js` from the readme unless you go to the docs website.