### PR TITLE
Add restore method

### DIFF
--- a/dist/core/crud.js
+++ b/dist/core/crud.js
@@ -133,6 +133,30 @@ var Crud = function (_Request) {
     }
 
     /**
+     * Sends a config.suffixes.restore request to emulate a
+     * restore request
+     *
+     * @param {Number} id
+     * @return {Promise}
+     */
+
+  }, {
+    key: 'restore',
+    value: function restore(id) {
+      var urlParams = [];
+
+      if (Number.isInteger(id)) {
+        this.id(id);
+      }
+
+      if (Object.prototype.hasOwnProperty.call(this.config.suffixes, 'restore')) {
+        urlParams.push(this.config.suffixes.restore);
+      }
+
+      return this.model.buildRequest(this.config.methods.restore, urlParams);
+    }
+
+    /**
      * Makes a request to create a new model based off the method and suffix for create
      *
      * @param {Object} data The data to be sent over for creation of model

--- a/dist/core/defaults.js
+++ b/dist/core/defaults.js
@@ -75,7 +75,8 @@ exports.default = {
   methods: {
     create: 'post',
     update: 'post',
-    destroy: 'post'
+    destroy: 'post',
+    restore: 'post'
   },
 
   /**
@@ -127,7 +128,8 @@ exports.default = {
   suffixes: {
     create: 'create',
     update: 'update',
-    destroy: 'destroy'
+    destroy: 'destroy',
+    restore: 'restore'
   },
 
   /**

--- a/dist/core/request.js
+++ b/dist/core/request.js
@@ -92,7 +92,7 @@ var Request = function (_Routes) {
       type = type.toLowerCase();
 
       if (!this.isAllowedRequestType(type)) {
-        return;
+        throw new Error('This request type is not allowed.');
       }
 
       this.beforeRequest(type, url);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rapid.js",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compile": "babel --presets=es2015 -d dist src",
     "copy-dev": "npm run compile && rm -rf ./demo/rapid && cp -R ./dist ./demo/rapid",
     "prepublish": "npm run compile",
-    "lint": "eslint src/**/*.js test/**/*.js",
+    "lint": "eslint --ext .js src test",
     "unit": "jest --maxWorkers 2",
     "unit:watch": "jest test/**/*.test.js --watch"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rapid.js",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/rapid.js",
   "scripts": {

--- a/src/core/crud.js
+++ b/src/core/crud.js
@@ -81,6 +81,27 @@ class Crud extends Request {
   }
 
   /**
+   * Sends a config.suffixes.restore request to emulate a
+   * restore request
+   *
+   * @param {Number} id
+   * @return {Promise}
+   */
+  restore (id) {
+    const urlParams = [];
+
+    if (Number.isInteger(id)) {
+      this.id(id);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(this.config.suffixes, 'restore')) {
+      urlParams.push(this.config.suffixes.restore);
+    }
+
+    return this.model.buildRequest(this.config.methods.restore, urlParams);
+  }
+
+  /**
    * Makes a request to create a new model based off the method and suffix for create
    *
    * @param {Object} data The data to be sent over for creation of model

--- a/src/core/defaults.js
+++ b/src/core/defaults.js
@@ -141,5 +141,5 @@ export default {
   afterRequest(response) {},
 
   // eslint-disable-next-line no-unused-vars
-  onError(response) {}
+  onError(response) {},
 };

--- a/src/core/defaults.js
+++ b/src/core/defaults.js
@@ -71,6 +71,7 @@ export default {
     create: 'post',
     update: 'post',
     destroy: 'post',
+    restore: 'post',
   },
 
   /**
@@ -123,6 +124,7 @@ export default {
     create: 'create',
     update: 'update',
     destroy: 'destroy',
+    restore: 'restore',
   },
 
   /**
@@ -133,17 +135,11 @@ export default {
   trailingSlash: false,
 
   // eslint-disable-next-line no-unused-vars
-  beforeRequest (type, url) {
-
-  },
+  beforeRequest(type, url) {},
 
   // eslint-disable-next-line no-unused-vars
-  afterRequest (response) {
-
-  },
+  afterRequest(response) {},
 
   // eslint-disable-next-line no-unused-vars
-  onError (response) {
-
-  },
+  onError(response) {}
 };

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -48,7 +48,7 @@ class Request extends Routes {
     type = type.toLowerCase();
 
     if (!this.isAllowedRequestType(type)) {
-      return;
+      throw new Error('This request type is not allowed.');
     }
 
     this.beforeRequest(type, url);

--- a/test/crud.test.js
+++ b/test/crud.test.js
@@ -68,7 +68,7 @@ describe('The basic CRUD methods should work', () => {
     testModel.restore('');
     expect(testModel.debugger.data.lastUrl).toBe('api/test-model/restore');
     expect((testModel.debugger.data.lastRequest.type === 'post')).toBeTruthy();
-    
+
   });
 
   const anotherTestModel = createModel({

--- a/test/crud.test.js
+++ b/test/crud.test.js
@@ -60,4 +60,10 @@ describe('The basic CRUD methods should work', () => {
     testModel.destroy(12345, {});
     expect(testModel.debugger.data.lastUrl).toBe('api/test-model/12345/delete');
   });
+
+  it('that restore should work', () => {
+    testModel.restore(12345, {});
+    expect(testModel.debugger.data.lastUrl).toBe('api/test-model/12345/restore');
+  });
+
 });

--- a/test/crud.test.js
+++ b/test/crud.test.js
@@ -62,8 +62,33 @@ describe('The basic CRUD methods should work', () => {
   });
 
   it('that restore should work', () => {
-    testModel.restore(12345, {});
+    testModel.restore(12345);
     expect(testModel.debugger.data.lastUrl).toBe('api/test-model/12345/restore');
+
+    testModel.restore('');
+    expect(testModel.debugger.data.lastUrl).toBe('api/test-model/restore');
+    expect((testModel.debugger.data.lastRequest.type === 'post')).toBeTruthy();
+    
+  });
+
+  const anotherTestModel = createModel({
+    modelName: 'testModel',
+    methods: {
+      restore: 'get',
+    },
+    suffixes: {
+      restore: 'undelete',
+    },
+  });
+
+  it('that restore suffix and request type should work', () => {
+    anotherTestModel.restore(12345);
+    expect(anotherTestModel.debugger.data.lastUrl).toBe('api/test-model/12345/undelete');
+
+    anotherTestModel.restore('');
+    expect(anotherTestModel.debugger.data.lastUrl).toBe('api/test-model/undelete');
+
+    expect((anotherTestModel.debugger.data.lastRequest.type === 'get')).toBeTruthy();
   });
 
 });


### PR DESCRIPTION
This adds the `restore()` method that emulates restoring/undeleting a model / collection.

```js
photo.restore(123); // POST => /api/photo/123/restore
```